### PR TITLE
v0.1.103: macOS + Windows Full (WebEngine) build variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -572,6 +572,251 @@ jobs:
           name: notepatra-macos-arm64
           path: build/Notepatra.dmg
 
+  # ─── v0.1.103: macOS Intel "Full" flavor (bundles QtWebEngine) ──────
+  # A NEW job (the arm64 job above stays untouched and Lite). Runs on the
+  # Intel macos-13 runner so everything — Rust core, QScintilla, Qt — is
+  # native x86_64 (no cross-compile). Qt5 + QtWebEngine come from aqt
+  # (install-qt-action); QScintilla comes from `brew install qscintilla2`
+  # which gives an x86_64 dylib on macos-13. macdeployqt bundles
+  # QtWebEngineCore.framework + Helpers/QtWebEngineProcess.app + the
+  # WebEngine Resources (.pak / icudtl.dat) when the binary links
+  # WebEngine, so the diagram tool + inline Vega-Lite charts render
+  # natively instead of the "preview needs the Full build" stub.
+  build-macos-full:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Qt5 + WebEngine (aqt)
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
+        with:
+          version: '5.15.2'
+          host: 'mac'
+          target: 'desktop'
+          arch: 'clang_64'
+          modules: 'qtcharts qtwebengine'
+          dir: '${{ runner.temp }}/Qt'
+
+      - name: Install QScintilla (brew, x86_64 on macos-13)
+        run: |
+          # macos-13 is an Intel runner, so brew's bottle is x86_64 — which
+          # matches the aqt clang_64 Qt and the native cargo build. aqt does
+          # not ship QScintilla, so we take brew's. (On Apple-silicon runners
+          # this would be arm64; that's why the arm job builds from source.)
+          brew install qscintilla2
+          echo "=== QScintilla brew artifacts ==="
+          find "$(brew --prefix)" -name "libqscintilla2_qt5*.dylib" 2>/dev/null
+          find "$(brew --prefix)" -name "qsciscintilla.h" 2>/dev/null
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-14
+
+      - name: Build Rust core
+        run: cd rust-core && cargo build --release
+
+      - name: Build C++ Full (WebEngine)
+        run: |
+          # Qt root = parent of the bin dir that holds qmake from aqt.
+          QMAKE=$(find "$RUNNER_TEMP/Qt" -name "qmake" -type f 2>/dev/null | grep -v Tools | head -1)
+          QT_PATH=$(dirname "$(dirname "$QMAKE")")
+          echo "Qt root (aqt): $QT_PATH"
+          export PATH="$QT_PATH/bin:$PATH"
+
+          BREW=$(brew --prefix)
+          QSC_LIB=$(find "$BREW" -name "libqscintilla2_qt5*.dylib" -type f 2>/dev/null | head -1)
+          QSC_HDR=$(find "$BREW" -name "qsciscintilla.h" 2>/dev/null | head -1)
+          QSC_INC=$(dirname "$(dirname "$QSC_HDR")")
+          [ -z "$QSC_LIB" ] && { echo "::error::libqscintilla2_qt5 dylib not found"; exit 1; }
+          [ -z "$QSC_HDR" ] && { echo "::error::qsciscintilla.h not found"; exit 1; }
+          echo "QScintilla lib: $QSC_LIB"
+          echo "QScintilla inc: $QSC_INC"
+
+          mkdir -p build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release \
+            -DNOTEPATRA_WITH_WEBENGINE=ON \
+            -DCMAKE_PREFIX_PATH="$QT_PATH;$QSC_INC" \
+            -DQSCINTILLA_INCLUDE="$QSC_INC" \
+            -DQSCINTILLA_LIB="$QSC_LIB"
+          make VERBOSE=1 -j"$(sysctl -n hw.ncpu)" 2>&1 | tail -200
+          ls -lh Notepatra.app/Contents/MacOS/notepatra
+          otool -L Notepatra.app/Contents/MacOS/notepatra | grep -i webengine | head -3 \
+            || echo "WARN: full build did not link WebEngine"
+
+      - name: Create DMG (full)
+        run: |
+          QMAKE=$(find "$RUNNER_TEMP/Qt" -name "qmake" -type f 2>/dev/null | grep -v Tools | head -1)
+          QT_PATH=$(dirname "$(dirname "$QMAKE")")
+          export PATH="$QT_PATH/bin:$PATH"
+          BREW=$(brew --prefix)
+
+          APP=build/Notepatra.app
+          FW="$APP/Contents/Frameworks"
+          mkdir -p "$FW"
+
+          # ─── Step 1: macdeployqt bundles Qt frameworks for the main binary.
+          # Because notepatra links WebEngine here, this ALSO bundles
+          # QtWebEngineCore.framework + Helpers/QtWebEngineProcess.app +
+          # the WebEngine Resources (.pak / icudtl.dat).
+          echo "=== macdeployqt ==="
+          macdeployqt "$APP"
+
+          # ─── Step 1b: Bundle OpenSSL 3 dylibs — REQUIRED for HTTPS.
+          # aqt's Qt5 on mac links system Secure Transport for TLS in some
+          # builds, but to match the arm job's portability guarantee we
+          # bundle Homebrew openssl@3 and rewrite refs to @rpath. If
+          # openssl@3 isn't present we warn rather than hard-fail (Full
+          # bundle's headline feature is chart rendering, not networking).
+          OPENSSL_PREFIX=$(brew --prefix openssl@3 2>/dev/null || echo "$BREW/opt/openssl@3")
+          echo "=== OpenSSL source: $OPENSSL_PREFIX ==="
+          for lib in libssl.3.dylib libcrypto.3.dylib; do
+            SRC="$OPENSSL_PREFIX/lib/$lib"
+            if [ ! -f "$SRC" ]; then
+              echo "::warning::$SRC missing — bundling skipped, HTTPS may use system TLS"
+              continue
+            fi
+            cp "$SRC" "$FW/$lib"
+            chmod u+w "$FW/$lib"
+            install_name_tool -id "@rpath/$lib" "$FW/$lib"
+            echo "  ✓ bundled $lib"
+          done
+          install_name_tool -change "$OPENSSL_PREFIX/lib/libcrypto.3.dylib" \
+            "@rpath/libcrypto.3.dylib" "$FW/libssl.3.dylib" 2>/dev/null || true
+          QTNET_BIN="$APP/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
+          if [ -f "$QTNET_BIN" ]; then
+            chmod u+w "$QTNET_BIN"
+            install_name_tool -change "$OPENSSL_PREFIX/lib/libssl.3.dylib" \
+              "@rpath/libssl.3.dylib" "$QTNET_BIN" 2>/dev/null || true
+            install_name_tool -change "$OPENSSL_PREFIX/lib/libcrypto.3.dylib" \
+              "@rpath/libcrypto.3.dylib" "$QTNET_BIN" 2>/dev/null || true
+            echo "  ✓ rewrote QtNetwork OpenSSL refs → @rpath"
+          fi
+
+          # ─── Step 2: Copy QScintilla dylib into the bundle + rewrite its
+          # load commands (macdeployqt doesn't know about it). Adapted for the
+          # brew x86_64 layout under $(brew --prefix).
+          QSC_SRC=$(find "$BREW" -name "libqscintilla2_qt5*.dylib" -type f 2>/dev/null | head -1)
+          if [ -z "$QSC_SRC" ]; then
+            echo "::error::QScintilla dylib not found — bundle would be unusable"
+            exit 1
+          fi
+          echo "QScintilla source: $QSC_SRC"
+          cp "$QSC_SRC" "$FW/libqscintilla2_qt5.15.dylib"
+          chmod u+w "$FW/libqscintilla2_qt5.15.dylib"
+          QSC_BUNDLED="$FW/libqscintilla2_qt5.15.dylib"
+          install_name_tool -id "@rpath/libqscintilla2_qt5.15.dylib" "$QSC_BUNDLED"
+
+          echo "=== Before rewrite ==="
+          otool -L "$QSC_BUNDLED"
+          otool -L "$QSC_BUNDLED" | tail -n +2 | awk '{print $1}' | while read -r DEP; do
+            case "$DEP" in
+              /opt/homebrew*|/usr/local*)
+                if echo "$DEP" | grep -q "\.framework/"; then
+                  FW_NAME=$(echo "$DEP" | sed -E 's|.*/([^/]+)\.framework/Versions/([^/]+)/.*|\1|')
+                  FW_VER=$(echo "$DEP"  | sed -E 's|.*/([^/]+)\.framework/Versions/([^/]+)/.*|\2|')
+                  NEW="@rpath/${FW_NAME}.framework/Versions/${FW_VER}/${FW_NAME}"
+                else
+                  NEW="@rpath/$(basename "$DEP")"
+                fi
+                echo "  rewrite: $DEP -> $NEW"
+                install_name_tool -change "$DEP" "$NEW" "$QSC_BUNDLED"
+                ;;
+            esac
+          done
+          echo "=== After rewrite ==="
+          otool -L "$QSC_BUNDLED"
+          codesign --force --sign - "$QSC_BUNDLED"
+
+          # ─── Step 2b: Force-copy QtPrintSupport.framework if macdeployqt
+          # skipped it (only libqscintilla2 links it). brew x86_64 layout.
+          if [ ! -d "$FW/QtPrintSupport.framework" ]; then
+            QTPS_SRC=$(find "$QT_PATH/lib" -maxdepth 1 -name "QtPrintSupport.framework" -type d 2>/dev/null | head -1)
+            if [ -n "$QTPS_SRC" ]; then
+              echo "=== Copying QtPrintSupport.framework (macdeployqt skipped it) ==="
+              cp -R "$QTPS_SRC" "$FW/"
+              QTPS_BIN="$FW/QtPrintSupport.framework/Versions/5/QtPrintSupport"
+              chmod u+w "$QTPS_BIN"
+              install_name_tool -id "@rpath/QtPrintSupport.framework/Versions/5/QtPrintSupport" "$QTPS_BIN"
+              otool -L "$QTPS_BIN" | tail -n +2 | awk '{print $1}' | while read -r DEP; do
+                case "$DEP" in
+                  /opt/homebrew*|/usr/local*)
+                    if echo "$DEP" | grep -q "\.framework/"; then
+                      FW_NAME=$(echo "$DEP" | sed -E 's|.*/([^/]+)\.framework/Versions/([^/]+)/.*|\1|')
+                      FW_VER=$(echo "$DEP"  | sed -E 's|.*/([^/]+)\.framework/Versions/([^/]+)/.*|\2|')
+                      NEW="@rpath/${FW_NAME}.framework/Versions/${FW_VER}/${FW_NAME}"
+                    else
+                      NEW="@rpath/$(basename "$DEP")"
+                    fi
+                    install_name_tool -change "$DEP" "$NEW" "$QTPS_BIN"
+                    ;;
+                esac
+              done
+              codesign --force --sign - "$QTPS_BIN"
+            fi
+          fi
+
+          # ─── Step 3: WebEngine verification — the whole point of the Full
+          # bundle. If macdeployqt didn't bundle QtWebEngineCore.framework,
+          # charts would show the stub on the user's Mac, so fail loudly.
+          if [ ! -d "$FW/QtWebEngineCore.framework" ]; then
+            echo "::error::QtWebEngineCore.framework missing from bundle — Full build would still show the chart stub"
+            echo "=== Frameworks dir ==="
+            ls -la "$FW"
+            exit 1
+          fi
+          echo "✓ QtWebEngineCore.framework present in bundle"
+
+          # ─── Step 4: Sign inner libs/frameworks/plugins, then the bundle
+          # last with entitlements + hardened runtime (Tahoe requirement).
+          ENTITLEMENTS="$GITHUB_WORKSPACE/resources/entitlements.plist"
+          if [ ! -f "$ENTITLEMENTS" ]; then
+            echo "::error::entitlements.plist missing — Tahoe launch will fail"
+            exit 1
+          fi
+          find "$APP/Contents/Frameworks" -type f \( -name "*.dylib" -o -name "*.so" \) 2>/dev/null | \
+            while read -r lib; do
+              codesign --force --sign - --options runtime --timestamp=none "$lib" 2>/dev/null || true
+            done
+          find "$APP/Contents/Frameworks" -type d -name "*.framework" 2>/dev/null | \
+            while read -r fw; do
+              codesign --force --sign - --options runtime --timestamp=none "$fw" 2>/dev/null || true
+            done
+          find "$APP/Contents/PlugIns" -type f -name "*.dylib" 2>/dev/null | \
+            while read -r plug; do
+              codesign --force --sign - --options runtime --timestamp=none "$plug" 2>/dev/null || true
+            done
+          codesign --force --deep --sign - \
+            --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --timestamp=none \
+            "$APP"
+          codesign -v --verbose=4 "$APP" || {
+            echo "::error::codesign verification failed — Tahoe will reject this bundle"
+            exit 1
+          }
+          echo "✓ Bundle signed with hardened runtime + entitlements"
+
+          # ─── Step 5: Create the DMG (retry on hdiutil "Resource busy").
+          rm -f notepatra-macos-x64-full.dmg
+          for attempt in 1 2 3; do
+            if hdiutil create -volname "Notepatra" -srcfolder "$APP" -ov \
+                              -format UDZO -nospotlight notepatra-macos-x64-full.dmg; then
+              echo "✓ DMG built on attempt $attempt"
+              break
+            fi
+            echo "hdiutil create failed (attempt $attempt) — detaching stale volumes and retrying"
+            hdiutil detach "/Volumes/Notepatra" -force 2>/dev/null || true
+            sleep $((attempt * 3))
+            if [ "$attempt" = "3" ]; then
+              echo "::error::hdiutil create failed after 3 attempts"; exit 1
+            fi
+          done
+
+      - name: Upload DMG (full)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: notepatra-macos-x64-full
+          path: notepatra-macos-x64-full.dmg
+
   build-windows:
     runs-on: windows-latest
     permissions:
@@ -1397,6 +1642,223 @@ jobs:
           $msiSize = [math]::Round((Get-Item "notepatra-local-ai-$version.msi").Length / 1MB, 2)
           Write-Host "✓ Built notepatra-local-ai-$version.msi ($msiSize MB)"
 
+      # ─── v0.1.103: Windows "Full" flavor (bundles QtWebEngine) ───────
+      # The lite bundle above is the default download; the Full bundle adds
+      # QtWebEngine so the diagram tool + inline Vega-Lite charts render
+      # natively on Windows instead of the "preview needs the Full build"
+      # stub. QtWebEngine is ALREADY installed by the Install Qt5 step
+      # (modules: qtwebengine), so this just flips NOTEPATRA_WITH_WEBENGINE=ON
+      # and runs windeployqt WITHOUT --no-translations (WebEngine needs the
+      # qtwebengine_locales/ .pak files).
+      - name: Build C++ Full (WebEngine)
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path build-full -Force | Out-Null
+          Set-Location build-full
+          $qtRoot = "${{ steps.qscintilla.outputs.QT_ROOT }}"
+          # Same VS-generator detection as the lite configure step.
+          $vsMajor = 0
+          if ($env:VisualStudioVersion) {
+              $vsMajor = [int]($env:VisualStudioVersion.Split('.')[0])
+          }
+          switch ($vsMajor) {
+              18 { $vsGen = "Visual Studio 18 2026" }
+              17 { $vsGen = "Visual Studio 17 2022" }
+              default {
+                  Write-Host "::warning::Unrecognised VisualStudioVersion='$($env:VisualStudioVersion)'; falling back to VS 17 2022."
+                  $vsGen = "Visual Studio 17 2022"
+              }
+          }
+          Write-Host "Using CMake generator: $vsGen  (from VisualStudioVersion=$($env:VisualStudioVersion))"
+          cmake .. -G "$vsGen" -A x64 `
+            "-DCMAKE_PREFIX_PATH=$qtRoot" `
+            "-DQSCINTILLA_INCLUDE=${{ steps.qscintilla.outputs.QSC_INC }}" `
+            "-DQSCINTILLA_LIB=${{ steps.qscintilla.outputs.QSC_LIB }}" `
+            -DNOTEPATRA_WITH_WEBENGINE=ON 2>&1 | Tee-Object -FilePath ../cmake-configure-full.log
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::cmake configure (full) failed"; exit 1 }
+          cmake --build . --config Release 2>&1 | Tee-Object -FilePath ../cmake-build-full.log
+          $buildExit = $LASTEXITCODE
+          Write-Host "=== Errors and warnings only (full) ==="
+          Get-Content ../cmake-build-full.log | Select-String -Pattern "error|fatal" | Select-Object -First 50 | ForEach-Object { Write-Host $_ }
+          Write-Host "=== Last 60 lines of cmake build output (full) ==="
+          Get-Content ../cmake-build-full.log -Tail 60 | ForEach-Object { Write-Host $_ }
+          if ($buildExit -ne 0) { Write-Host "::error::cmake build (full) failed (exit $buildExit)"; exit 1 }
+          Write-Host "=== Searching for notepatra.exe (full) ==="
+          Get-ChildItem -Path . -Recurse -Filter "notepatra.exe" | ForEach-Object { Write-Host $_.FullName }
+
+      - name: Bundle Windows Full
+        shell: pwsh
+        run: |
+          # Mirror the lite "Verify exe, embed icon, bundle Qt + QScintilla
+          # DLLs" step, with two differences:
+          #   1. windeployqt runs WITHOUT --no-translations so the
+          #      qtwebengine_locales/ .pak files come along.
+          #   2. A WebEngine-specific critical-files assertion at the end.
+          $exe = Get-ChildItem -Path build-full -Recurse -Filter "notepatra.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $exe) {
+            Write-Host "::error::notepatra.exe (full) not found anywhere under build-full/"
+            Get-ChildItem -Path build-full -Recurse | Select-Object FullName
+            exit 1
+          }
+          Write-Host "Found: $($exe.FullName) ($([math]::Round($exe.Length / 1MB, 2)) MB)"
+
+          $outDir = "notepatra-win-full"
+          New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+          Copy-Item $exe.FullName "$outDir\"
+
+          $qtRoot = "${{ steps.qscintilla.outputs.QT_ROOT }}"
+          $qtBin = "$qtRoot\bin"
+          $qtPlugins = "$qtRoot\plugins"
+
+          # Bundle the QScintilla DLL (windeployqt doesn't know about it)
+          $qsciDll = "${{ steps.qscintilla.outputs.QSC_DLL }}"
+          if ($qsciDll -and (Test-Path $qsciDll)) {
+            Copy-Item $qsciDll "$outDir\"
+            Write-Host "Bundled QScintilla DLL: $qsciDll"
+          } else {
+            $found = Get-ChildItem -Path $qtRoot -Recurse -Filter "qscintilla2_qt5.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($found) {
+              Copy-Item $found.FullName "$outDir\"
+              Write-Host "Bundled QScintilla DLL (found via search): $($found.FullName)"
+            } else {
+              Write-Host "::error::qscintilla2_qt5.dll not found anywhere — exe will fail at startup"
+              exit 1
+            }
+          }
+
+          # ── windeployqt — NOTE: no --no-translations so WebEngine locales ship ──
+          $windeployqt = "$qtRoot\bin\windeployqt.exe"
+          if (Test-Path $windeployqt) {
+            Write-Host ""
+            Write-Host "════════════ windeployqt pass 1: notepatra.exe (full) ════════════"
+            & $windeployqt --release --compiler-runtime --no-opengl-sw `
+              --dir "$outDir" "$outDir\notepatra.exe" 2>&1
+            Write-Host "windeployqt pass 1 exit: $LASTEXITCODE"
+
+            Write-Host ""
+            Write-Host "════════════ windeployqt pass 2: qscintilla2_qt5.dll (full) ════════════"
+            & $windeployqt --release --no-opengl-sw `
+              --dir "$outDir" "$outDir\qscintilla2_qt5.dll" 2>&1
+            Write-Host "windeployqt pass 2 exit: $LASTEXITCODE"
+          } else {
+            Write-Host "::warning::windeployqt not at $windeployqt — skipping, manual copy will handle it"
+          }
+
+          # ── Manual core Qt DLL copy (same set as the lite step) ──
+          Write-Host ""
+          Write-Host "════════════ Manual DLL copy (deterministic fallback) ════════════"
+          $coreDlls = @("Qt5Core.dll", "Qt5Gui.dll", "Qt5Widgets.dll", "Qt5Network.dll", "Qt5PrintSupport.dll")
+          foreach ($dll in $coreDlls) {
+            $src = Join-Path $qtBin $dll
+            if (Test-Path $src) {
+              Copy-Item $src "$outDir\" -Force
+              Write-Host "  ✓ $dll"
+            } else {
+              Write-Host "  ✗ MISSING: $src"
+            }
+          }
+
+          # ── OpenSSL 1.1 DLLs (same search-dir logic as the lite step) ──
+          $opensslDlls = @("libcrypto-1_1-x64.dll", "libssl-1_1-x64.dll")
+          $sslSearchDirs = @(
+            "C:\Program Files\OpenSSL-Win64\bin",
+            "C:\Program Files\OpenSSL\bin",
+            "C:\tools\OpenSSL-Win64\bin",
+            "${{ runner.temp }}/OpenSSL"
+          )
+          foreach ($dll in $opensslDlls) {
+            $found = $null
+            foreach ($d in $sslSearchDirs) {
+              if (Test-Path "$d\$dll") { $found = "$d\$dll"; break }
+            }
+            if (-not $found) {
+              foreach ($d in $sslSearchDirs) {
+                if (Test-Path $d) {
+                  $hit = Get-ChildItem -Path $d -Recurse -Filter $dll -ErrorAction SilentlyContinue | Select-Object -First 1
+                  if ($hit) { $found = $hit.FullName; break }
+                }
+              }
+            }
+            if ($found) {
+              Copy-Item $found "$outDir\" -Force
+              Write-Host "  ✓ $dll (from $found)"
+            } else {
+              Write-Host "::error::$dll NOT FOUND — HTTPS will fail at runtime"
+              exit 1
+            }
+          }
+
+          # Qt plugins — same set as the lite step
+          $plugins = @(
+            @{src="platforms\qwindows.dll"; dest="platforms"},
+            @{src="styles\qwindowsvistastyle.dll"; dest="styles"},
+            @{src="imageformats\qico.dll"; dest="imageformats"},
+            @{src="imageformats\qjpeg.dll"; dest="imageformats"},
+            @{src="imageformats\qsvg.dll"; dest="imageformats"},
+            @{src="iconengines\qsvgicon.dll"; dest="iconengines"},
+            @{src="printsupport\windowsprintersupport.dll"; dest="printsupport"},
+            @{src="bearer\qgenericbearer.dll"; dest="bearer"}
+          )
+          foreach ($p in $plugins) {
+            $src = Join-Path $qtPlugins $p.src
+            $destDir = Join-Path $outDir $p.dest
+            New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+            if (Test-Path $src) {
+              Copy-Item $src $destDir -Force
+              Write-Host "  ✓ $($p.src)"
+            } else {
+              Write-Host "  ✗ MISSING: $src"
+            }
+          }
+
+          Write-Host ""
+          Write-Host "════════════ Final full bundle contents ════════════"
+          Get-ChildItem $outDir -Recurse | Select-Object FullName, Length | Format-Table -AutoSize
+          $totalSize = (Get-ChildItem $outDir -Recurse | Measure-Object Length -Sum).Sum / 1MB
+          Write-Host "Total package size: $([math]::Round($totalSize, 1)) MB"
+
+          # ── Critical-files assertion: lite essentials + WebEngine bits ──
+          $critical = @(
+            "$outDir\notepatra.exe",
+            "$outDir\Qt5Core.dll",
+            "$outDir\Qt5Gui.dll",
+            "$outDir\Qt5Widgets.dll",
+            "$outDir\qscintilla2_qt5.dll",
+            "$outDir\platforms\qwindows.dll",
+            "$outDir\QtWebEngineProcess.exe",
+            "$outDir\resources\icudtl.dat",
+            "$outDir\Qt5WebEngineCore.dll",
+            "$outDir\Qt5WebEngineWidgets.dll"
+          )
+          $missing = @()
+          foreach ($f in $critical) {
+            if (-not (Test-Path $f)) { $missing += $f }
+          }
+          if ($missing.Count -gt 0) {
+            Write-Host "::error::Critical files missing from Full bundle:"
+            foreach ($f in $missing) { Write-Host "  - $f" }
+            exit 1
+          }
+          Write-Host "✓ All critical files present (incl. WebEngine) — Full bundle should render charts"
+
+          # File-association helper scripts (HKCU-only), same as lite.
+          if (Test-Path "installers\register-associations.bat") {
+            Copy-Item "installers\register-associations.bat" ".\notepatra-win-full\" -Force
+          }
+          if (Test-Path "installers\unregister-associations.bat") {
+            Copy-Item "installers\unregister-associations.bat" ".\notepatra-win-full\" -Force
+          }
+
+          # ── Portable zip ──
+          Compress-Archive -Path "$outDir\*" -DestinationPath "notepatra-windows-x64-full.zip" -Force
+          Write-Host "✓ Created notepatra-windows-x64-full.zip ($([math]::Round((Get-Item notepatra-windows-x64-full.zip).Length / 1MB, 1)) MB)"
+
+      - name: Upload artifact (portable zip — full)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: notepatra-windows-x64-full
+          path: notepatra-windows-x64-full.zip
+
       - name: Upload artifact (portable zip)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -1527,7 +1989,7 @@ jobs:
           }
 
   release:
-    needs: [build-linux, build-linux-arm, build-macos-arm, build-windows]
+    needs: [build-linux, build-linux-arm, build-macos-arm, build-macos-full, build-windows]
     # Pinned to ubuntu-24.04 to match every other Linux job in this file.
     # Was previously ubuntu-latest, which would silently roll forward and
     # could shift cosign / SLSA action runtime expectations under our feet.
@@ -1564,8 +2026,16 @@ jobs:
             tar czf notepatra-linux-arm64-full.tar.gz -C notepatra-linux-arm64-full notepatra
           fi
           cp notepatra-macos-arm64/Notepatra.dmg notepatra-macos-arm64.dmg
+          # v0.1.103 — macOS Intel "Full" flavor DMG (bundles QtWebEngine).
+          if [ -d notepatra-macos-x64-full ]; then
+            cp notepatra-macos-x64-full/notepatra-macos-x64-full.dmg notepatra-macos-x64-full.dmg
+          fi
           if [ -d notepatra-windows-x64 ]; then
             cd notepatra-windows-x64 && zip -r ../notepatra-windows-x64.zip . && cd ..
+          fi
+          # v0.1.103 — Windows "Full" flavor portable zip (bundles QtWebEngine).
+          if [ -d notepatra-windows-x64-full ]; then
+            cp notepatra-windows-x64-full/notepatra-windows-x64-full.zip notepatra-windows-x64-full.zip
           fi
           # Rename Windows installer to the canonical name used in release assets
           TAG="${GITHUB_REF##*/}"
@@ -1627,8 +2097,9 @@ jobs:
           #   sha256sum -c SHA256SUMS
           for f in notepatra-linux-x64.tar.gz notepatra-linux-arm64.tar.gz \
                    notepatra-linux-x64-full.tar.gz notepatra-linux-arm64-full.tar.gz \
-                   notepatra-macos-arm64.dmg \
-                   notepatra-windows-x64.zip notepatra-setup-*.exe notepatra-*.msi \
+                   notepatra-macos-arm64.dmg notepatra-macos-x64-full.dmg \
+                   notepatra-windows-x64.zip notepatra-windows-x64-full.zip \
+                   notepatra-setup-*.exe notepatra-*.msi \
                    notepatra_*_amd64.deb notepatra_*_arm64.deb \
                    notepatra-local-ai_*_amd64.deb notepatra-local-ai_*_arm64.deb \
                    notepatra-*x86_64.rpm notepatra-*aarch64.rpm \
@@ -1683,8 +2154,9 @@ jobs:
           # ties the signature to this repo + workflow + commit SHA.
           for f in notepatra-linux-x64.tar.gz notepatra-linux-arm64.tar.gz \
                    notepatra-linux-x64-full.tar.gz notepatra-linux-arm64-full.tar.gz \
-                   notepatra-macos-arm64.dmg \
-                   notepatra-windows-x64.zip notepatra-setup-*.exe notepatra-*.msi \
+                   notepatra-macos-arm64.dmg notepatra-macos-x64-full.dmg \
+                   notepatra-windows-x64.zip notepatra-windows-x64-full.zip \
+                   notepatra-setup-*.exe notepatra-*.msi \
                    notepatra_*_amd64.deb notepatra_*_arm64.deb \
                    notepatra-local-ai_*_amd64.deb notepatra-local-ai_*_arm64.deb \
                    notepatra-*x86_64.rpm notepatra-*aarch64.rpm \
@@ -1707,7 +2179,9 @@ jobs:
             notepatra-linux-x64-full.tar.gz
             notepatra-linux-arm64-full.tar.gz
             notepatra-macos-arm64.dmg
+            notepatra-macos-x64-full.dmg
             notepatra-windows-x64.zip
+            notepatra-windows-x64-full.zip
             notepatra-setup-*.exe
             notepatra-*.msi
             notepatra_*_amd64.deb
@@ -1727,7 +2201,9 @@ jobs:
             notepatra-linux-x64-full.tar.gz
             notepatra-linux-arm64-full.tar.gz
             notepatra-macos-arm64.dmg
+            notepatra-macos-x64-full.dmg
             notepatra-windows-x64.zip
+            notepatra-windows-x64-full.zip
             notepatra-setup-*.exe
             notepatra-*.msi
             notepatra_*_amd64.deb
@@ -1748,8 +2224,12 @@ jobs:
             notepatra-linux-arm64-full.tar.gz.pem
             notepatra-macos-arm64.dmg.sig
             notepatra-macos-arm64.dmg.pem
+            notepatra-macos-x64-full.dmg.sig
+            notepatra-macos-x64-full.dmg.pem
             notepatra-windows-x64.zip.sig
             notepatra-windows-x64.zip.pem
+            notepatra-windows-x64-full.zip.sig
+            notepatra-windows-x64-full.zip.pem
             notepatra-setup-*.exe.sig
             notepatra-setup-*.exe.pem
             notepatra-*.msi.sig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic Ver
 
 ---
 
+## [0.1.103] — 2026-05-26
+
+**Diagrams + inline charts now render on macOS and Windows — new "Full" (WebEngine) download variants.** v0.1.102 shipped the diagram tool, but the macOS `.dmg` and Windows installers were Lite-only (no WebEngine), so the diagram canvas (and inline Vega-Lite charts) fell back to the "preview needs the Full build" stub on those platforms. Linux already had a `-full` variant; now macOS and Windows do too.
+
+### Added
+- **`notepatra-windows-x64-full.zip`** — Windows Full portable build. The CI Qt install already bundled the `qtwebengine` module, so the Full variant adds a `-DNOTEPATRA_WITH_WEBENGINE=ON` build + `windeployqt` (QtWebEngineProcess.exe, `resources/*.pak`, `icudtl.dat`, WebEngine locales) with a critical-files assertion.
+- **`notepatra-macos-x64-full.dmg`** — macOS Full build via a new `build-macos-full` CI job on an Intel (`macos-13`) runner: Qt 5.15.2 + `qtwebengine` from aqtinstall, `macdeployqt`-bundled `QtWebEngineCore.framework` + `QtWebEngineProcess.app`, code-signed DMG. **Intel/x86_64 — runs under Rosetta 2 on Apple Silicon** (Qt 5.15.2 has no arm64 WebEngine; Homebrew dropped it). The default arm64 Lite DMG is unchanged.
+- Both new artifacts are SHA256-summed, cosign-signed, SLSA-attested, and attached to the GitHub Release.
+
+### Notes
+- **Packaging / CI-only release** — no app code changed. The diagram tool, parser, and renderer are unchanged from v0.1.102; the `#ifdef NOTEPATRA_WITH_WEBENGINE` path already existed — macOS/Windows just never got a Full build until now.
+- Queued: a native-Qt (QGraphicsView) diagram renderer would let the diagram render in the Lite binary on every platform, removing the WebEngine dependency.
+
+---
+
 ## [0.1.102] — 2026-05-25
 
 **Diagrams — author flow charts, ER diagrams and system designs from a text DSL, with AI generation, a live canvas, and browser-native export.** A new first-class diagramming tool (Full flavor), opened from the toolbar ("Diagram", next to Noter) or Features → Diagram.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(Notepatra VERSION 0.1.102 LANGUAGES CXX)
+project(Notepatra VERSION 0.1.103 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Not a port. Not a wrapper. Something new — **for everyone**.
 
 I asked: **what would a small native code editor look like if it was built today, in 2026, when AI is part of every developer's workflow, and ran natively on Linux + macOS + Windows from one codebase?**
 
-The answer: a tiny native executable — under 12 MB bare (~11.5 MB on Linux x64) on every platform — with a Rust-powered core, Scintilla editing engine, and local-first AI integration (cloud backends optional). v0.1.102 downloads: 4.1 MB Linux x64 (tarball, Qt from the system), 27.5 MB on macOS (DMG with bundled Qt), 32.7–42.2 MB on Windows (MSI/zip/setup.exe with bundled Qt DLLs). An editor that can fix your broken JSON with regex in milliseconds — and when regex isn't enough, it asks your AI to figure it out — local by default, six cloud backends one click away when you want a frontier model. No telemetry. No subscription. No mandatory API key.
+The answer: a tiny native executable — under 12 MB bare (~11.5 MB on Linux x64) on every platform — with a Rust-powered core, Scintilla editing engine, and local-first AI integration (cloud backends optional). v0.1.103 downloads: 4.1 MB Linux x64 (tarball, Qt from the system), 27.5 MB on macOS (DMG with bundled Qt), 32.7–42.2 MB on Windows (MSI/zip/setup.exe with bundled Qt DLLs). An editor that can fix your broken JSON with regex in milliseconds — and when regex isn't enough, it asks your AI to figure it out — local by default, six cloud backends one click away when you want a frontier model. No telemetry. No subscription. No mandatory API key.
 
 Notepatra started on Linux — because that's where the gap was. But great tools shouldn't have borders. **Notepatra runs on Linux, Windows, and macOS.** Same codebase. Same features. No one gets left behind.
 
@@ -253,7 +253,7 @@ A first-class diagramming surface (Full flavor), opened from the toolbar next to
 **Why this hybrid?**
 - **C++** because Qt and QScintilla are C++ — zero friction for UI
 - **Rust** because file I/O, text processing, and parsing must never crash — Rust's ownership system guarantees memory safety
-- **Result**: the speed of C++, the safety of Rust. The bare executable is **under 12 MB** on every platform (~11.5 MB Linux x64, similar on macOS / Windows). Latest v0.1.102 download sizes: **4.1 MB** Linux x64 tar.gz · **3.9 MB** Linux ARM64 tar.gz · **27.5 MB** macOS DMG (with bundled Qt) · **42.2 MB** Windows MSI · **32.7 MB** Windows NSIS · **37.3 MB** Windows portable zip. _Installed footprint on Windows is ~75-85 MB after the MSI extracts bundled Qt + QScintilla DLLs — normal for any Qt-based installer._
+- **Result**: the speed of C++, the safety of Rust. The bare executable is **under 12 MB** on every platform (~11.5 MB Linux x64, similar on macOS / Windows). Latest v0.1.103 download sizes: **4.1 MB** Linux x64 tar.gz · **3.9 MB** Linux ARM64 tar.gz · **27.5 MB** macOS DMG (with bundled Qt) · **42.2 MB** Windows MSI · **32.7 MB** Windows NSIS · **37.3 MB** Windows portable zip. _Installed footprint on Windows is ~75-85 MB after the MSI extracts bundled Qt + QScintilla DLLs — normal for any Qt-based installer._
 
 ---
 
@@ -273,7 +273,7 @@ irm https://notepatra.org/install.ps1 | iex
 
 That's it. Auto-detects your OS, downloads the right binary, installs it, adds to PATH, creates shortcuts.
 
-### Or download manually — [Latest release: v0.1.102](https://github.com/singhpratech/notepatra/releases/latest)
+### Or download manually — [Latest release: v0.1.103](https://github.com/singhpratech/notepatra/releases/latest)
 
 | Platform | Download | Size | What's inside |
 |---|---|---|---|
@@ -296,11 +296,11 @@ For one-time-install-then-every-user-sees-it on a shared machine, or silent push
 
 | OS | Artefact | Silent admin install |
 |---|---|---|
-| 🪟 **Windows** | [`notepatra-x.x.x.msi`](https://github.com/singhpratech/notepatra/releases/latest) | `msiexec /i notepatra-0.1.102.msi /quiet` — installs to `C:\Program Files\Notepatra\`, adds system PATH, registers HKCR file associations, all-users Start Menu. WiX-built, MajorUpgrade-aware, SCCM-friendly. |
+| 🪟 **Windows** | [`notepatra-x.x.x.msi`](https://github.com/singhpratech/notepatra/releases/latest) | `msiexec /i notepatra-0.1.103.msi /quiet` — installs to `C:\Program Files\Notepatra\`, adds system PATH, registers HKCR file associations, all-users Start Menu. WiX-built, MajorUpgrade-aware, SCCM-friendly. |
 | 🍎 **macOS** | [`Notepatra.dmg`](https://github.com/singhpratech/notepatra/releases/latest) | Mount + `sudo cp -R "/Volumes/Notepatra/Notepatra.app" /Applications/` from a deployment script. Or open the DMG manually and drag to `/Applications` (admin password). Notarised + stapled. |
-| 🐧 **Debian / Ubuntu / Mint / Pop!_OS** (x64 + ARM64) | [`notepatra_0.1.102_amd64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra_0.1.102_amd64.deb` — installs to `/opt/notepatra/` + symlink at `/usr/bin/notepatra`, hicolor icons, `.desktop` registration. ARM64: replace `amd64` → `arm64`. |
-| 🐧 **Fedora / RHEL / CentOS Stream / Rocky / Alma** (x64 + ARM64) | [`notepatra-0.1.102-1.x86_64.rpm`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo dnf install ./notepatra-0.1.102-1.x86_64.rpm` — same layout as the .deb. ARM64: replace `x86_64` → `aarch64`. Bundles QScintilla 2.14.1 alongside the binary because Fedora ships an incompatible packaging. |
-| 🐧 **Arch / openSUSE Tumbleweed / Manjaro / EndeavourOS / other glibc 2.38+** | [`Notepatra-0.1.102-x86_64.AppImage`](https://github.com/singhpratech/notepatra/releases/latest) | `chmod +x Notepatra-0.1.102-x86_64.AppImage && sudo cp Notepatra-0.1.102-x86_64.AppImage /opt/notepatra.AppImage && sudo ln -s /opt/notepatra.AppImage /usr/local/bin/notepatra`. Requires glibc 2.38+ (Ubuntu 24.04+, Fedora 40+, Arch, Tumbleweed). Older distros: use the .deb / .rpm. |
+| 🐧 **Debian / Ubuntu / Mint / Pop!_OS** (x64 + ARM64) | [`notepatra_0.1.103_amd64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra_0.1.103_amd64.deb` — installs to `/opt/notepatra/` + symlink at `/usr/bin/notepatra`, hicolor icons, `.desktop` registration. ARM64: replace `amd64` → `arm64`. |
+| 🐧 **Fedora / RHEL / CentOS Stream / Rocky / Alma** (x64 + ARM64) | [`notepatra-0.1.103-1.x86_64.rpm`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo dnf install ./notepatra-0.1.103-1.x86_64.rpm` — same layout as the .deb. ARM64: replace `x86_64` → `aarch64`. Bundles QScintilla 2.14.1 alongside the binary because Fedora ships an incompatible packaging. |
+| 🐧 **Arch / openSUSE Tumbleweed / Manjaro / EndeavourOS / other glibc 2.38+** | [`Notepatra-0.1.103-x86_64.AppImage`](https://github.com/singhpratech/notepatra/releases/latest) | `chmod +x Notepatra-0.1.103-x86_64.AppImage && sudo cp Notepatra-0.1.103-x86_64.AppImage /opt/notepatra.AppImage && sudo ln -s /opt/notepatra.AppImage /usr/local/bin/notepatra`. Requires glibc 2.38+ (Ubuntu 24.04+, Fedora 40+, Arch, Tumbleweed). Older distros: use the .deb / .rpm. |
 
 > All artefacts ship with cosign `.sig` + `.pem` for keyless Sigstore verification and SLSA build provenance. See **[Verify your download](#verify-your-download)** below.
 
@@ -310,9 +310,9 @@ For teams that **can't or won't send code to public LLM endpoints** — regulate
 
 | OS | Artefact | Silent admin install |
 |---|---|---|
-| 🪟 **Windows** | [`notepatra-local-ai-0.1.102.msi`](https://github.com/singhpratech/notepatra/releases/latest) | `msiexec /i notepatra-local-ai-0.1.102.msi /quiet` — installs to `C:\Program Files\Notepatra Local AI\`, distinct UpgradeCode so SCCM treats it as its own product. Add/Remove Programs shows "Notepatra Local AI". |
-| 🐧 **Debian/Ubuntu x64** | [`notepatra-local-ai_0.1.102_amd64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra-local-ai_0.1.102_amd64.deb` |
-| 🐧 **Debian/Ubuntu ARM64** | [`notepatra-local-ai_0.1.102_arm64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra-local-ai_0.1.102_arm64.deb` |
+| 🪟 **Windows** | [`notepatra-local-ai-0.1.103.msi`](https://github.com/singhpratech/notepatra/releases/latest) | `msiexec /i notepatra-local-ai-0.1.103.msi /quiet` — installs to `C:\Program Files\Notepatra Local AI\`, distinct UpgradeCode so SCCM treats it as its own product. Add/Remove Programs shows "Notepatra Local AI". |
+| 🐧 **Debian/Ubuntu x64** | [`notepatra-local-ai_0.1.103_amd64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra-local-ai_0.1.103_amd64.deb` |
+| 🐧 **Debian/Ubuntu ARM64** | [`notepatra-local-ai_0.1.103_arm64.deb`](https://github.com/singhpratech/notepatra/releases/latest) | `sudo apt install ./notepatra-local-ai_0.1.103_arm64.deb` |
 
 **The binary physically cannot reach `api.openai.com`, `api.anthropic.com`, `openrouter.ai`, `api.mistral.ai`, `generativelanguage.googleapis.com`, or any other public LLM endpoint.** Every `QNetworkAccessManager` request goes through an allowlist that only accepts:
 
@@ -324,7 +324,7 @@ For teams that **can't or won't send code to public LLM endpoints** — regulate
 
 Local Ollama, local llama.cpp, self-hosted Ollama on the LAN, and any other OpenAI-compatible server you have installed locally or on your private network — **all continue to work** in the cloud-free build. Only public-cloud LLM endpoints are blocked. The cloud-URL paste box is stripped from the UI as well, so users can't even type a public host. Auditors can confirm by running `strings notepatra | grep -c openai.com` — zero hits.
 
-On Linux the two flavors share the same `notepatra` binary name on disk; `apt` Conflicts ensures only one of `notepatra` / `notepatra-local-ai` is installed at a time, swap transactionally with `sudo apt install ./notepatra-local-ai_0.1.102_amd64.deb`. On Windows the two MSIs are independent products (different UpgradeCode + ProductName + install dir) so they can coexist if needed; admins typically push one or the other based on policy. `notepatra --version` self-identifies the build: `Notepatra v0.1.102 (cloud-free / local-ai)` for the local-ai flavor, `Notepatra v0.1.102` for the regular flavor.
+On Linux the two flavors share the same `notepatra` binary name on disk; `apt` Conflicts ensures only one of `notepatra` / `notepatra-local-ai` is installed at a time, swap transactionally with `sudo apt install ./notepatra-local-ai_0.1.103_amd64.deb`. On Windows the two MSIs are independent products (different UpgradeCode + ProductName + install dir) so they can coexist if needed; admins typically push one or the other based on policy. `notepatra --version` self-identifies the build: `Notepatra v0.1.103 (cloud-free / local-ai)` for the local-ai flavor, `Notepatra v0.1.103` for the regular flavor.
 
 ### Verify your download
 
@@ -549,7 +549,7 @@ cl /LD myplugin.cpp /Fe:myplugin.dll
 | **Kate / Gedit** | ~30 MB | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ |
 | **Notepatra** | **4.1 / 27.5 / 42.2 MB** | ✓ C++/Rust | ✓ Ollama | ✓ regex + AI | ✓ Rust mmap | ✓ | ✓ | ✓ | ✓ GPL-3 |
 
-> *Notepatra download sizes are Linux x64 tar.gz / macOS DMG / Windows MSI from v0.1.102. Linux is just the binary (Qt is system-installed). macOS and Windows include bundled Qt. The bare `notepatra` executable inside is under 12 MB on every platform (Linux 11.5 MB, similar on macOS / Windows). Compressed download is much smaller because tar.gz / DMG / MSI all compress the binary plus shared libraries.*
+> *Notepatra download sizes are Linux x64 tar.gz / macOS DMG / Windows MSI from v0.1.103. Linux is just the binary (Qt is system-installed). macOS and Windows include bundled Qt. The bare `notepatra` executable inside is under 12 MB on every platform (Linux 11.5 MB, similar on macOS / Windows). Compressed download is much smaller because tar.gz / DMG / MSI all compress the binary plus shared libraries.*
 
 ---
 
@@ -586,6 +586,7 @@ Notepatra follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic 
 
 | Version | Date | Highlights |
 |---|---|---|
+| [**v0.1.103**](https://github.com/singhpratech/notepatra/releases/tag/v0.1.103) | 2026-05-26 | **macOS + Windows Full (WebEngine) download variants so the diagram tool + inline charts render there** — `notepatra-windows-x64-full.zip` + `notepatra-macos-x64-full.dmg` (the mac Full DMG is Intel/Rosetta). Packaging/CI-only; no app code changed since v0.1.102. |
 | [**v0.1.102**](https://github.com/singhpratech/notepatra/releases/tag/v0.1.102) | 2026-05-25 | **Diagrams — flow / ER / system from a text DSL, with AI generation, a live canvas, and PNG/SVG/PDF/HTML export.** New first-class diagram tool (Full flavor): the text-first `.npd` DSL is the source of truth and the canvas is a live projection. Create three ways — **AI Generate** (describe it → review the generated `.npd` → Insert), templates, or write `.npd` directly (plus **Import Mermaid**). 5 shapes, 12 icons, directed/labelled/bidirectional arrows, label-overflow→hover, 5 palettes, infinite pan/zoom. Toolbar button next to Noter + in-tool Help cheat-sheet + `samples/diagram_showcase.npd` + `npd_render` CLI. **Also fixed:** `CMAKE_AUTORCC` was never enabled, so `.qrc` resources (`vega.qrc` inline charts, `icons.qrc`, the diagram render layer) weren't bundling in Full builds — now corrected. 53/53 ctest pass. |
 | [**v0.1.101**](https://github.com/singhpratech/notepatra/releases/tag/v0.1.101) | 2026-05-25 | **In-app updater finalizes even when a prior download is locked.** On macOS the update downloaded + verified, then failed with "Could not finalize the download file." `Updater::runUpdate()` moved the verified `~/Downloads/<name>.part` to `<name>` with `if (exists) remove(); rename();` but ignored the remove result — and on macOS a `.dmg` the updater previously `open`ed stays MOUNTED in Finder, which macOS won't let you delete, so `QFile::rename` then refused to overwrite it and every retry re-wedged. Fix: new `uniqueDestPath()` lands the file under a browser-style `<name> (1).dmg` when the destination can't be removed, plus a copy+remove fallback. Net improvement on all platforms. New `test_updater` cases cover the dedup for `.dmg`/`.tar.gz`/`.msi`/`.deb`/`.AppImage` (a version-dot edge case was caught + fixed pre-release). 47/47 ctest pass. |
 | [**v0.1.100**](https://github.com/singhpratech/notepatra/releases/tag/v0.1.100) | 2026-05-25 | **🎉 100th release — window opens centred on Windows.** On a cold start / file-double-click the window could open with its title bar above the top of the screen, hiding the min/max/close buttons. Root cause: position was saved with `QWidget::x()`/`y()` (Qt FRAME coords, incl. the title bar) but restored with `setGeometry()` (CLIENT coords), so on Windows the title bar climbed up by its own height each launch until the controls left the screen; the ≥100 px on-screen clamp didn't catch a body-on-screen / title-bar-off-top window. Fix: new `centeredWindowRect()` helper — both restore sites (config + session) now centre on the **saved size** with a title-bar-height top margin instead of restoring the saved x/y. Maximized state + window size preserved; only on-screen position is dropped (always centred). Also confirmed (no change): the AI Interaction Log at `%APPDATA%\Notepatra\ai-logs\` persists across upgrades and survives uninstall (installers never touch `%APPDATA%`). 47/47 ctest pass. |

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -299,7 +299,7 @@
   <div class="topbar-left">
     <img src="https://raw.githubusercontent.com/singhpratech/notepatra/main/resources/notepatra-64.png" alt="Notepatra">
     <a href="/" class="brand">Notepatra</a>
-    <span class="tag">v0.1.102 docs</span>
+    <span class="tag">v0.1.103 docs</span>
   </div>
   <nav class="topbar-right">
     <a href="/">Home</a>
@@ -402,7 +402,7 @@
   <p><strong>The AI runs as an agent.</strong> Tick <strong>Coding Mode</strong> in the AI dock and the model gets 5 native tools — <code>read_file</code>, <code>list_dir</code>, <code>search</code>, <code>write_file</code>, <code>apply_diff</code> — plus three-layer path safety, a 25-call hard cap per turn, and persistent per-workspace chat history. See <a href="#ai-coding-mode">Coding Mode (agentic)</a> below for the full surface.</p>
 
   <div class="callout info">
-    <strong>What "0.1.x" means.</strong> Notepatra is built by a one-person team in the open and is not yet feature-complete relative to mature editors. The roadmap is deliberately public. Latest release is v0.1.102 (May 2026). See <a href="#faq">the FAQ</a> for what's shipped vs. planned.
+    <strong>What "0.1.x" means.</strong> Notepatra is built by a one-person team in the open and is not yet feature-complete relative to mature editors. The roadmap is deliberately public. Latest release is v0.1.103 (May 2026). See <a href="#faq">the FAQ</a> for what's shipped vs. planned.
   </div>
 
   <h2 id="install" class="anchor-target">Install</h2>
@@ -617,7 +617,7 @@ Remove-Item -Recurse -Force "$env:APPDATA\Notepatra"</code></pre>
     <li><strong>macOS:</strong> <code>~/Library/Application Support/notepatra/plugins/&lt;pack&gt;/</code></li>
     <li><strong>Windows:</strong> <code>%APPDATA%/notepatra/plugins/&lt;pack&gt;/</code></li>
   </ul>
-  <p>As of v0.1.102, the Full flavor ships the <em>charts</em> pack bundled (it's the same binary — the pack is "installed" if WebEngine was linked at compile time). v0.1.66+ adds in-app download / SHA-256 verification / runtime <code>QPluginLoader</code> activation so packs can be added without swapping binaries.</p>
+  <p>As of v0.1.103, the Full flavor ships the <em>charts</em> pack bundled (it's the same binary — the pack is "installed" if WebEngine was linked at compile time). v0.1.66+ adds in-app download / SHA-256 verification / runtime <code>QPluginLoader</code> activation so packs can be added without swapping binaries.</p>
 
   <table>
     <thead>
@@ -634,7 +634,7 @@ Remove-Item -Recurse -Force "$env:APPDATA\Notepatra"</code></pre>
         <td><code>pdf</code></td>
         <td>≈ 12 MB</td>
         <td>Rasterises PDFs to PNG pages so vision-capable AI models can read them. Powered by Poppler-Qt5.</td>
-        <td>Still queued (not shipped as of v0.1.102). Until then, dragging a PDF into the AI dock shows the "use a vision-capable model" error bubble.</td>
+        <td>Still queued (not shipped as of v0.1.103). Until then, dragging a PDF into the AI dock shows the "use a vision-capable model" error bubble.</td>
       </tr>
     </tbody>
   </table>
@@ -679,7 +679,7 @@ make -j$(nproc)
     <li><strong>Do I lose anything by staying on Lite?</strong> No — every editor / lexer / AI / Git / data / plugin feature works identically. The only difference is that <code>generate_chart</code> tool results paint as a "Charts Pack required" card instead of as an inline rendered chart. You can still see the spec via [View JSON instead] and copy it elsewhere.</li>
     <li><strong>Can I downgrade Full → Lite?</strong> Yes. Just download the Lite tarball and replace the binary. Your config / chat history / connections are preserved (they live under <code>~/.config/notepatra</code>, not inside the binary).</li>
     <li><strong>Will the chart spec data be lost if I'm on Lite?</strong> No — the AI's tool result is preserved in your chat history just like any other tool result. If you upgrade to Full later, opening the same chat shows the rendered chart for those past results.</li>
-    <li><strong>When does the in-app installer ship?</strong> Still queued as of v0.1.102. The architectural pieces (plugin_loader, manifest schema, download path) are scaffolded in v0.1.66; what's left is the actual HTTP fetch + SHA-256 verify + <code>QPluginLoader::load</code> wiring, plus testing across macOS / Windows runners.</li>
+    <li><strong>When does the in-app installer ship?</strong> Still queued as of v0.1.103. The architectural pieces (plugin_loader, manifest schema, download path) are scaffolded in v0.1.66; what's left is the actual HTTP fetch + SHA-256 verify + <code>QPluginLoader::load</code> wiring, plus testing across macOS / Windows runners.</li>
   </ul>
 
   <h2 id="ui-overview" class="anchor-target">UI overview</h2>
@@ -719,7 +719,7 @@ make -j$(nproc)
   <p><strong>Load-path optimisations (v0.1.88).</strong> Opening a 118 MB UTF-8 file used to take ~1.5 s and peak ~700 MB RAM; v0.1.88 brings it to ~600 ms and ~360 MB. Three fixes in <code>rust-core/src/file_io.rs</code>: a UTF-8 fast path validates with <code>std::str::from_utf8</code> (SIMD-accelerated) and skips the <code>UTF_8.decode()</code> allocation entirely when the mmap bytes are already valid UTF-8; EOL detection is bounded to the first 64 KB instead of two full-text scans; and the Rust&rarr;C FFI handoff now delivers a length-prefixed <code>Box&lt;[u8]&gt;</code> through a new <code>npc_free_file_text(ptr, len)</code> entry-point instead of the old NUL-terminated <code>CString</code> round-trip — saves ~118 MB of heap on a 118 MB file. UTF-16 / UTF-32 / Windows-1252 paths unchanged.</p>
 
   <h2 id="languages-lexers" class="anchor-target">Languages &amp; lexers</h2>
-  <p>Notepatra ships <strong>92 language lexers</strong> as of v0.1.102 (covering 226 file extensions). The Language menu is split into a narrow two-tier layout — <em>Common</em> + <em>SQL Dialects</em> at the top, <em>More Languages</em> as an alphabetical submenu of the rest. Extensions are auto-detected from the filename.</p>
+  <p>Notepatra ships <strong>92 language lexers</strong> as of v0.1.103 (covering 226 file extensions). The Language menu is split into a narrow two-tier layout — <em>Common</em> + <em>SQL Dialects</em> at the top, <em>More Languages</em> as an alphabetical submenu of the rest. Extensions are auto-detected from the filename.</p>
   <p><strong>Core (Qt-bundled):</strong> Python, JavaScript/TypeScript/JSX, CoffeeScript, C/C++, C#, D, Java/Kotlin, HTML/PHP, CSS/SCSS/LESS, XML, JSON, SQL (ANSI / T-SQL / PL/SQL / MySQL / PostgreSQL / SQLite), Bash, Batch, Ruby, Perl, Lua, TCL, Fortran, Matlab, Octave, IDL, NASM, MASM, Verilog, VHDL, TeX, PostScript, POV, Spice, AVS, Properties, PO, IntelHex, SRecord, Markdown, YAML, Diff, Pascal, CMake, Makefile.</p>
   <p><strong>v0.1.55 additions (32 dedicated lexers, keyword tables verified against official specs):</strong> Dart · Solidity · Zig · Vala · Hack · Julia · R · Protobuf · F# · HCL/Terraform · Thrift · GraphQL · GDScript · Nim · Cython · Mojo · Crystal · Elixir · Scala · Groovy · Apex · Jinja · Liquid · Twig · Dockerfile · Fish · Nushell · TOML · DotEnv · Gitignore · JSON5 · BibTeX. Each ships with comment / uncomment / block-comment syntax (Ctrl+Q / Ctrl+Shift+Q) and proper file-extension routing — <code>.dart</code>, <code>.zig</code>, <code>.jl</code>, <code>.toml</code>, <code>.ex</code>, <code>Cargo.toml</code>, <code>Dockerfile</code>, <code>.gitignore</code>, <code>.env</code>, <code>.fish</code>, <code>.json5</code>, <code>.tf</code>, etc. now point at their dedicated lexers instead of falling back to the closest-fit generic.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
       "applicationCategory": "DeveloperApplication",
       "applicationSubCategory": "TextEditor",
       "description": "Native C++/Rust code editor built from scratch for the AI era. Bare executable is under 12 MB across platforms (11.5 MB on Linux x64); full downloads are 4.1 MB (Linux x64 tar.gz), 27.5 MB (macOS DMG with bundled Qt), 42.2 MB (Windows MSI with bundled Qt DLLs). 226 file types. 92 language lexers. JSON / HTML / SQL fixers. AI dock dropdown ships six backends: Ollama, llama.cpp (GGUF), OpenRouter, Ollama Cloud, OpenAI, Azure OpenAI; the llama.cpp entry also accepts a user-configured URL so it can reach any OpenAI-compatible server (examples redacted). Free forever. Linux, Windows, macOS.",
-      "softwareVersion": "0.1.102",
+      "softwareVersion": "0.1.103",
       "fileSize": "11.5 MB",
       "downloadUrl": "https://github.com/singhpratech/notepatra/releases/latest",
       "installUrl": "https://notepatra.org/#install",
@@ -151,7 +151,7 @@
           "name": "How big is the Notepatra binary?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "The bare Notepatra executable is under 12 MB across every platform (11.5 MB on Linux x64). Latest v0.1.102 download sizes: 4.1 MB Linux x64 tar.gz, 3.9 MB Linux ARM64 tar.gz, 27.5 MB macOS DMG (with bundled Qt), 42.2 MB Windows MSI / 32.7 MB NSIS / 37.3 MB portable zip (with bundled Qt + QScintilla DLLs). After Windows install the on-disk footprint is ~75-85 MB because the MSI extracts the bundled Qt5 DLLs and QScintilla DLL out of the compressed payload — that's normal for any Qt app installer. Linux installs stay tiny (~11.5 MB on disk / bare) because Qt5 comes from your distro repo. Notepatra installs at 9–85 MB depending on platform."
+            "text": "The bare Notepatra executable is under 12 MB across every platform (11.5 MB on Linux x64). Latest v0.1.103 download sizes: 4.1 MB Linux x64 tar.gz, 3.9 MB Linux ARM64 tar.gz, 27.5 MB macOS DMG (with bundled Qt), 42.2 MB Windows MSI / 32.7 MB NSIS / 37.3 MB portable zip (with bundled Qt + QScintilla DLLs). After Windows install the on-disk footprint is ~75-85 MB because the MSI extracts the bundled Qt5 DLLs and QScintilla DLL out of the compressed payload — that's normal for any Qt app installer. Linux installs stay tiny (~11.5 MB on disk / bare) because Qt5 comes from your distro repo. Notepatra installs at 9–85 MB depending on platform."
           }
         },
         {
@@ -167,7 +167,7 @@
           "name": "What languages and file types does Notepatra support?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Notepatra supports 226 file types with 92 language lexers as of v0.1.102: Python, JavaScript, TypeScript, C, C++, C#, Java, Kotlin, Rust, Go, Dart, Solidity, Zig, Vala, Hack, Julia, R, Protobuf, F#, HCL/Terraform, Thrift, GraphQL, GDScript, Nim, Cython, Mojo, Crystal, Elixir, Scala, Groovy, Apex, HTML, CSS, SQL (5 dialects), JSON, JSON5, YAML, TOML, Markdown, Bash, Fish, Nushell, Ruby, Perl, Lua, Fortran, Verilog, VHDL, MATLAB, LaTeX, BibTeX, Jinja, Liquid, Twig, Dockerfile, DotEnv, Gitignore, and many more."
+            "text": "Notepatra supports 226 file types with 92 language lexers as of v0.1.103: Python, JavaScript, TypeScript, C, C++, C#, Java, Kotlin, Rust, Go, Dart, Solidity, Zig, Vala, Hack, Julia, R, Protobuf, F#, HCL/Terraform, Thrift, GraphQL, GDScript, Nim, Cython, Mojo, Crystal, Elixir, Scala, Groovy, Apex, HTML, CSS, SQL (5 dialects), JSON, JSON5, YAML, TOML, Markdown, Bash, Fish, Nushell, Ruby, Perl, Lua, Fortran, Verilog, VHDL, MATLAB, LaTeX, BibTeX, Jinja, Liquid, Twig, Dockerfile, DotEnv, Gitignore, and many more."
           }
         },
         {
@@ -1284,8 +1284,8 @@
     <div id="scroll-progress" aria-hidden="true"></div>
 
     <!-- Sticky download CTA — appears after the hero scrolls away. -->
-    <a id="sticky-cta" href="#download" aria-label="Download Notepatra v0.1.102">
-        Download v0.1.102 ↓
+    <a id="sticky-cta" href="#download" aria-label="Download Notepatra v0.1.103">
+        Download v0.1.103 ↓
     </a>
 
     <div class="bg-glow"></div>
@@ -1312,7 +1312,7 @@
 
     <!-- Hero -->
     <div class="hero">
-        <div class="hero-badge">v0.1.102 · Now Available · Linux · Windows · macOS</div>
+        <div class="hero-badge">v0.1.103 · Now Available · Linux · Windows · macOS</div>
         <h1>The code editor built for the AI era</h1>
         <p>Tiny native binary (under 12 MB bare, ~4.1 MB compressed on Linux). C++ and Rust. 226 file types · 92 language lexers. JSON / HTML / SQL fixers — regex first, local AI as fallback. <strong>Local AI by default; cloud LLMs opt-in.</strong> Or pick the <a href="#download" style="color:#a87bc4; text-decoration:underline; text-underline-offset:3px;">Local AI build</a> for a binary that physically refuses to talk to public endpoints.</p>
 
@@ -1399,7 +1399,7 @@
 
     <!-- Download -->
     <section id="download">
-        <div class="section-label">Download v0.1.102</div>
+        <div class="section-label">Download v0.1.103</div>
         <div class="section-title">One-command install or direct download</div>
         <div class="section-desc">Auto-detecting installer scripts, or pick your platform from GitHub Releases. No telemetry. No tracking. Just a binary.</div>
 
@@ -1467,7 +1467,7 @@
                         margin-top: 18px; padding: 9px 16px; border-radius: 8px;
                         background: var(--green); color: white; text-decoration: none;
                         font-weight: 600; font-size: 13.5px;">
-                Get Notepatra v0.1.102 →
+                Get Notepatra v0.1.103 →
               </a>
             </div>
 
@@ -1510,7 +1510,7 @@
                         margin-top: 18px; padding: 9px 16px; border-radius: 8px;
                         background: #a87bc4; color: white; text-decoration: none;
                         font-weight: 600; font-size: 13.5px;">
-                Get Notepatra Local AI v0.1.102 →
+                Get Notepatra Local AI v0.1.103 →
               </a>
             </div>
           </div>
@@ -1990,39 +1990,39 @@
         <div class="version-list">
             <div class="version-card latest">
                 <div class="version-header">
-                    <div class="version-tag">v0.1.102 <span class="latest-pill">LATEST</span></div>
+                    <div class="version-tag">v0.1.103 <span class="latest-pill">LATEST</span></div>
                     <div class="version-meta">
-                        <span>2026-05-25</span>
-                        <span>· <strong>Diagrams — flow charts, ER diagrams and system designs from a text DSL, with AI generation, a live canvas, and browser-native export.</strong> Describe a diagram in plain English and a local model writes it, or author it in the tiny <code>.npd</code> language with a live preview — then export to PNG / SVG / PDF / HTML.</span>
+                        <span>2026-05-26</span>
+                        <span>· <strong>Diagrams + inline charts now render on macOS and Windows — new Full (WebEngine) download variants.</strong></span>
                         <span>· Full flavor · Linux · macOS · Windows</span>
                     </div>
                 </div>
                 <div class="version-changes">
                     <div class="version-section">
-                        <h5>Diagram tool (.npd) — text-first, AI-assisted</h5>
+                        <h5>Full (WebEngine) download variants for macOS + Windows</h5>
                         <ul>
-                            <li><strong>Three ways to create:</strong> <strong>AI Generate</strong> (describe it → review the generated <code>.npd</code> → Insert; undo/redo), Flow / ER / System templates, or write <code>.npd</code> directly — plus <strong>Import Mermaid</strong>. The text is the source of truth; the canvas is a live projection.</li>
-                            <li><strong>Rich visuals:</strong> 5 shapes (pill / box / decision diamond / database cylinder / icon), 12 icons, directed + labelled + bidirectional arrows, label-overflow→hover, 5 palettes, infinite pan/zoom canvas. Export to <strong>PNG / WebP / JPEG / SVG / PDF / HTML</strong>. Opens from a toolbar button next to Noter; a Help button has the full cheat-sheet.</li>
-                            <li><strong>Also fixed:</strong> a latent build issue (<code>CMAKE_AUTORCC</code> was never enabled) meant <code>.qrc</code> resources — inline Vega-Lite charts, AIPanel icons, and the new diagram layer — weren't bundling in Full builds. Now corrected.</li>
+                            <li><strong>New <code>notepatra-windows-x64-full.zip</code></strong> — Windows Full build with WebEngine bundled, so the diagram tool + inline charts render.</li>
+                            <li><strong>New <code>notepatra-macos-x64-full.dmg</code></strong> — macOS Full build, Intel/x86_64 (runs under Rosetta on Apple Silicon; Qt 5.15.2 has no arm64 WebEngine).</li>
+                            <li><strong>Packaging / CI-only</strong> — no app code changed; the diagram tool itself shipped in v0.1.102.</li>
                         </ul>
                     </div>
                 </div>
                 <div class="version-actions">
-                    <a href="https://github.com/singhpratech/notepatra/releases/tag/v0.1.102">Release page</a>
+                    <a href="https://github.com/singhpratech/notepatra/releases/tag/v0.1.103">Release page</a>
                     <a href="https://github.com/singhpratech/notepatra/blob/main/CHANGELOG.md">Full changelog</a>
-                    <a href="https://github.com/singhpratech/notepatra/commits/v0.1.102">Commits</a>
+                    <a href="https://github.com/singhpratech/notepatra/commits/v0.1.103">Commits</a>
             </div>
             <!-- v0.1.76 policy: only the LATEST release detail card is shown
                  on the website.  Every older release lives on GitHub —
                  single link below, no slim version rows. The previous
-                 latest card (v0.1.100) was DELETED — not demoted to a slim
-                 row — when v0.1.102 shipped, per feedback_website_release_detail_policy.
+                 latest card (v0.1.102) was DELETED — not demoted to a slim
+                 row — when v0.1.103 shipped, per feedback_website_release_detail_policy.
                  If you're tempted to add a "previous release" card again, read
                  that memory first. -->
 
             <!-- 100th-release MILESTONE — permanent slim card. Per the user
                  (2026-05-25): the 100th release is a milestone; this slim card
-                 STAYS even as v0.1.102 / v0.1.102 / … roll through as the LATEST
+                 STAYS even as v0.1.103 / v0.1.104 / … roll through as the LATEST
                  detail card above. Do NOT delete it on the next release — it is
                  the ONE intentional exception to the single-latest-card policy.
                  Full release reading still lives on GitHub (link below). -->
@@ -2066,7 +2066,7 @@
         <div class="features-grid">
             <div class="feature-card">
                 <h3>What is Notepatra?</h3>
-                <p>Notepatra is a native code editor written from scratch in C++17 with a Rust core for hot paths (memory-mapped I/O, Aho-Corasick search, Myers diff, formatters). Runs on Linux x64 / ARM64, macOS Apple Silicon, and Windows x64 from a single codebase. under-12 MB bare executable, no Electron runtime, no telemetry, no mandatory account. Local-first AI is built in: pick from Ollama, llama.cpp, OpenRouter, OpenAI, Azure OpenAI, or Ollama Cloud. As of v0.1.102: 226 file types · 92 language lexers, native DuckDB engine for the Data Analyst mode, agentic Coding Mode with read / list / search / write / apply_diff tools, Cursor-style Composer + Ctrl+I inline edit, multi-cursor, AI-driven git tools.</p>
+                <p>Notepatra is a native code editor written from scratch in C++17 with a Rust core for hot paths (memory-mapped I/O, Aho-Corasick search, Myers diff, formatters). Runs on Linux x64 / ARM64, macOS Apple Silicon, and Windows x64 from a single codebase. under-12 MB bare executable, no Electron runtime, no telemetry, no mandatory account. Local-first AI is built in: pick from Ollama, llama.cpp, OpenRouter, OpenAI, Azure OpenAI, or Ollama Cloud. As of v0.1.103: 226 file types · 92 language lexers, native DuckDB engine for the Data Analyst mode, agentic Coding Mode with read / list / search / write / apply_diff tools, Cursor-style Composer + Ctrl+I inline edit, multi-cursor, AI-driven git tools.</p>
             </div>
             <div class="feature-card">
                 <h3>Is it really free? What's the catch?</h3>
@@ -2078,7 +2078,7 @@
             </div>
             <div class="feature-card">
                 <h3>How big is the binary?</h3>
-                <p>The bare executable is <strong>under 12 MB</strong> (11.5 MB on Linux x64) across every platform. Latest v0.1.102 download sizes: <strong>4.1 MB</strong> Linux x64 tar.gz · <strong>3.9 MB</strong> Linux ARM64 tar.gz · <strong>27.5 MB</strong> macOS DMG · <strong>42.2 MB</strong> Windows MSI / <strong>32.7 MB</strong> NSIS / <strong>37.3 MB</strong> portable zip. <strong>Installed on Windows</strong> the on-disk footprint grows to ~75-85 MB because the MSI extracts bundled Qt5 + QScintilla DLLs out of the compressed payload — normal for every Qt-based installer. Linux stays tiny (~10 MB on disk) because Qt is a system package; macOS and Windows bundle Qt + QScintilla DLLs for portability.</p>
+                <p>The bare executable is <strong>under 12 MB</strong> (11.5 MB on Linux x64) across every platform. Latest v0.1.103 download sizes: <strong>4.1 MB</strong> Linux x64 tar.gz · <strong>3.9 MB</strong> Linux ARM64 tar.gz · <strong>27.5 MB</strong> macOS DMG · <strong>42.2 MB</strong> Windows MSI / <strong>32.7 MB</strong> NSIS / <strong>37.3 MB</strong> portable zip. <strong>Installed on Windows</strong> the on-disk footprint grows to ~75-85 MB because the MSI extracts bundled Qt5 + QScintilla DLLs out of the compressed payload — normal for every Qt-based installer. Linux stays tiny (~10 MB on disk) because Qt is a system package; macOS and Windows bundle Qt + QScintilla DLLs for portability.</p>
             </div>
             <div class="feature-card">
                 <h3>Does my code go to the cloud?</h3>
@@ -2086,7 +2086,7 @@
             </div>
             <div class="feature-card">
                 <h3>What languages does Notepatra highlight?</h3>
-                <p>226 file types via <strong>92 language lexers</strong> as of v0.1.102 — Python, JavaScript, TypeScript, C, C++, C#, Java, Kotlin, Rust, Go, Dart, Solidity, Zig, Vala, Hack, Julia, R, Protobuf, F#, HCL/Terraform, Thrift, GraphQL, GDScript, Nim, Cython, Mojo, Crystal, Elixir, Scala, Groovy, Apex, HTML, CSS, SQL (5 dialects), JSON, JSON5, YAML, TOML, Markdown, Bash, Fish, Nushell, Ruby, Perl, Lua, Fortran, Verilog, VHDL, MATLAB, LaTeX, BibTeX, Jinja, Liquid, Twig, Dockerfile, DotEnv, Gitignore, Pascal, CMake, Makefile, and more. Each lexer ships with comment / uncomment / block-comment syntax (Ctrl+Q / Ctrl+Shift+Q) and proper file-extension routing.</p>
+                <p>226 file types via <strong>92 language lexers</strong> as of v0.1.103 — Python, JavaScript, TypeScript, C, C++, C#, Java, Kotlin, Rust, Go, Dart, Solidity, Zig, Vala, Hack, Julia, R, Protobuf, F#, HCL/Terraform, Thrift, GraphQL, GDScript, Nim, Cython, Mojo, Crystal, Elixir, Scala, Groovy, Apex, HTML, CSS, SQL (5 dialects), JSON, JSON5, YAML, TOML, Markdown, Bash, Fish, Nushell, Ruby, Perl, Lua, Fortran, Verilog, VHDL, MATLAB, LaTeX, BibTeX, Jinja, Liquid, Twig, Dockerfile, DotEnv, Gitignore, Pascal, CMake, Makefile, and more. Each lexer ships with comment / uncomment / block-comment syntax (Ctrl+Q / Ctrl+Shift+Q) and proper file-extension routing.</p>
             </div>
             <div class="feature-card">
                 <h3>How do I verify a download is genuine?</h3>

--- a/release_notes/v0.1.103.md
+++ b/release_notes/v0.1.103.md
@@ -1,0 +1,38 @@
+# Notepatra v0.1.103
+
+**Diagrams + inline charts now render on macOS and Windows — new "Full" (WebEngine) download variants.**
+
+## What changed
+
+v0.1.102 shipped the diagram tool, but the macOS `.dmg` and Windows installers were **Lite-only** (no WebEngine), so on those platforms the diagram canvas fell back to its "preview needs the Full build" stub — the diagram (and inline Vega-Lite charts) couldn't render. Linux already had a `-full` variant; macOS and Windows did not.
+
+v0.1.103 adds **Full-flavor download variants for macOS and Windows**, mirroring the existing Linux `-full` artifacts. The default downloads stay Lite and small; grab the Full variant when you want the diagram tool and inline chart rendering.
+
+## New artifacts
+
+| Platform | Lite (default) | Full (renders diagrams + charts) |
+|----------|----------------|----------------------------------|
+| Linux x64 / ARM64 | `notepatra-linux-*.tar.gz` | `notepatra-linux-*-full.tar.gz` _(since v0.1.64)_ |
+| **Windows x64** | `.msi` / `.exe` / `.zip` | **`notepatra-windows-x64-full.zip`** _(new)_ |
+| **macOS** | `notepatra-macos-arm64.dmg` (Apple Silicon) | **`notepatra-macos-x64-full.dmg`** _(new)_ |
+
+## Notes on the macOS Full variant
+
+The macOS Full DMG is **Intel (x86_64)** and runs under **Rosetta 2** on Apple Silicon. Reason: Qt 5.15.2's prebuilt QtWebEngine is x86_64-only — Homebrew dropped WebEngine from `qt@5`, and no arm64 Qt 5.15 WebEngine binary exists upstream. Rather than build Chromium from source, the Full DMG is produced on an Intel runner via aqtinstall + `qtwebengine`, so it renders correctly on every Mac (natively on Intel, under Rosetta on M-series). The default arm64 Lite DMG is unchanged and stays native Apple Silicon.
+
+A future native-Qt diagram renderer (no WebEngine) would let the diagram render in the Lite binary on every platform — tracked separately.
+
+## How it's built
+
+- **Windows**: the CI Qt install already includes the `qtwebengine` module — the Full variant just adds a `-DNOTEPATRA_WITH_WEBENGINE=ON` build + `windeployqt` bundle (QtWebEngineProcess.exe + `resources/*.pak` + `icudtl.dat` + WebEngine locales) zipped as `notepatra-windows-x64-full.zip`.
+- **macOS**: a new `build-macos-full` CI job on `macos-13` (Intel) installs Qt 5.15.2 + `qtwebengine` via aqtinstall, builds Full, and `macdeployqt` bundles `QtWebEngineCore.framework` + `QtWebEngineProcess.app` + resources into a code-signed `notepatra-macos-x64-full.dmg`.
+- Both new artifacts are checksummed (SHA256SUMS), cosign-signed, SLSA-attested, and attached to the GitHub Release alongside the existing ones.
+
+## No app code changed
+
+This is a **packaging / CI-only** release — the diagram tool, parser, and renderer code are unchanged from v0.1.102. The `#ifdef NOTEPATRA_WITH_WEBENGINE` gate in `src/diagram/diagram_view.cpp` already supports the Full path; macOS/Windows simply never got a Full build until now.
+
+## Out of scope (queued)
+
+- Native-Qt (QGraphicsView) diagram renderer so Lite renders on every platform — removes the WebEngine dependency entirely.
+- `.npd` syntax highlighting + routing `*.npd` file-open to the diagram tab.


### PR DESCRIPTION
Adds **Full (WebEngine) download variants for macOS + Windows** so the diagram tool + inline Vega charts render there (v0.1.102 shipped Lite-only `.dmg`/`.msi`, which fell to the "preview needs the Full build" stub).

## What's new (CI/packaging only — no app code changed)
- **Windows**: `notepatra-windows-x64-full.zip` — the CI Qt already had `qtwebengine`, so this is a `-DNOTEPATRA_WITH_WEBENGINE=ON` build + `windeployqt` bundle with a WebEngine critical-files assertion.
- **macOS**: new `build-macos-full` job on `macos-13` (Intel) → `notepatra-macos-x64-full.dmg`. Qt 5.15.2 + `qtwebengine` via aqtinstall, `macdeployqt`-bundled framework. **Intel/x86_64, runs under Rosetta on Apple Silicon** (Qt 5.15.2 has no arm64 WebEngine; brew dropped it). Default arm64 Lite DMG untouched.
- Both wired into SHA256SUMS + cosign + SLSA + the Release attach list.

## This PR's purpose
CI is the test loop for the two new build paths — I can't build mac/Windows locally. **Windows is high-confidence** (just a flag + deploy). **macOS-Intel is the risk** (aqt WebEngine + macdeployqt framework bundling). Will iterate on CI failures until both `-full` artifacts build green, then merge + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)