### PR TITLE
docs: comparison table — add Diagrams + Notes columns + fix ~10 MB → ~12 MB

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1863,6 +1863,8 @@
                     <th>Size</th>
                     <th>AI Built-in</th>
                     <th>JSON Fixer</th>
+                    <th>Diagrams</th>
+                    <th>Notes</th>
                     <th>2 GB Files</th>
                     <th>Linux</th>
                     <th>Windows</th>
@@ -1873,7 +1875,9 @@
             <tbody>
                 <tr class="highlight-row">
                     <td>Notepatra</td>
-                    <td>~10 MB</td>
+                    <td>~12 MB</td>
+                    <td class="check">✓</td>
+                    <td class="check">✓</td>
                     <td class="check">✓</td>
                     <td class="check">✓</td>
                     <td class="check">✓</td>
@@ -1889,6 +1893,8 @@
                     <td class="cross">Plugin</td>
                     <td class="cross">✗</td>
                     <td class="cross">✗</td>
+                    <td class="cross">✗</td>
+                    <td class="cross">✗</td>
                     <td class="check">✓</td>
                     <td class="cross">✗</td>
                     <td class="check">✓</td>
@@ -1896,6 +1902,8 @@
                 <tr>
                     <td>VS Code</td>
                     <td>300 MB</td>
+                    <td class="cross">Extension</td>
+                    <td class="cross">Extension</td>
                     <td class="cross">Extension</td>
                     <td class="cross">Extension</td>
                     <td class="cross">✗</td>
@@ -1909,6 +1917,8 @@
                     <td>30 MB</td>
                     <td class="cross">✗</td>
                     <td class="cross">✗</td>
+                    <td class="cross">✗</td>
+                    <td class="cross">✗</td>
                     <td class="check">✓</td>
                     <td class="check">✓</td>
                     <td class="check">✓</td>
@@ -1918,6 +1928,8 @@
                 <tr>
                     <td>Kate</td>
                     <td>40 MB</td>
+                    <td class="cross">✗</td>
+                    <td class="cross">✗</td>
                     <td class="cross">✗</td>
                     <td class="cross">✗</td>
                     <td class="check">✓</td>
@@ -1930,6 +1942,8 @@
                     <td>Vim</td>
                     <td>3 MB</td>
                     <td class="cross">✗</td>
+                    <td class="cross">✗</td>
+                    <td class="cross">Plugin</td>
                     <td class="cross">✗</td>
                     <td class="check">✓</td>
                     <td class="check">✓</td>


### PR DESCRIPTION
Standalone docs-only fix (split out of the v0.1.103 PR so it ships independently of the mac/win Full CI work).

The "How Notepatra compares" table on notepatra.org omitted two of Notepatra's biggest differentiators — the built-in **Diagram tool** and the **Noter** meeting-notes workspace (no other lightweight editor ships either) — and the Notepatra Size cell still read `~10 MB`.

- Add **Diagrams** + **Notes** columns across all 6 editors (Notepatra ✓✓; VS Code "Extension"; Vim "Plugin" diagrams; others ✗).
- Fix Notepatra Size `~10 MB` → `~12 MB` (matches the Bare Binary stat card + rest of docs since v0.1.102).
- All 6 rows verified at 11 cells (aligned with the 11-column header).

Docs-only — no version bump, no code change. Merging redeploys Pages with the corrected table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)