### PR TITLE
DIAGNOSTIC: pinpoint Windows Noter test segfault (do not merge)

### DIFF
--- a/test_notes_panel_widget.cpp
+++ b/test_notes_panel_widget.cpp
@@ -99,6 +99,10 @@ static QString readAll(const QString &path) {
 }
 
 int main(int argc, char *argv[]) {
+    // DIAG (win-noter-segfault): unbuffered stdout so the LAST section header
+    // printed before a hard crash is captured by ctest --output-on-failure,
+    // pinpointing the exact failing section on Windows. No behaviour change.
+    setvbuf(stdout, nullptr, _IONBF, 0);
     QApplication app(argc, argv);
 
     QTemporaryDir tmpHome;

--- a/test_notes_panels.cpp
+++ b/test_notes_panels.cpp
@@ -485,6 +485,10 @@ static void testExtractPreflightClosedPort() {
 }
 
 int main(int argc, char *argv[]) {
+    // DIAG (win-noter-segfault): unbuffered stdout so the LAST section header
+    // printed before a hard crash is captured by ctest --output-on-failure,
+    // pinpointing the exact failing section on Windows. No behaviour change.
+    setvbuf(stdout, nullptr, _IONBF, 0);
     qputenv("QT_QPA_PLATFORM", "offscreen");
     QApplication app(argc, argv);
 


### PR DESCRIPTION
**Diagnostic only — do not merge; will be closed after the Windows run.**

`test_notes_panels` and `test_notes_panel_widget` hard-segfault on the Windows/VS2026 runner only. They pass 54/54 on Linux (Debug, Debug+ASan, Release). This PR adds unbuffered stdout to the two test mains so `ctest --output-on-failure` captures the EXACT last section before the crash (the CI capture was block-buffered, hiding the real crash point).

Goal: read the precise failing section from the build-windows log, then revert this and ship the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)