### PR TITLE
v0.1.115 hotfix: Windows build break (unistd.h) + honest download counter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2182,7 +2182,7 @@
     <footer>
         <!-- ─── Download counter (live from GitHub Releases API) ─── -->
         <div id="download-counter" style="max-width: 720px; margin: 0 auto 32px; padding: 20px 24px; background: var(--c-surface); border: 1px solid var(--c-border); border-radius: 12px;">
-            <div style="font-size: 11px; color: var(--c-accent); text-transform: uppercase; letter-spacing: 1.5px; font-weight: 600; margin-bottom: 14px; text-align: center;">Total downloads</div>
+            <div style="font-size: 11px; color: var(--c-accent); text-transform: uppercase; letter-spacing: 1.5px; font-weight: 600; margin-bottom: 14px; text-align: center;">GitHub asset downloads</div>
             <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; text-align: center;">
                 <div>
                     <div style="font-size: 32px; line-height: 1;">🐧</div>
@@ -2257,10 +2257,12 @@
         }
 
         // ─── Live download counter — sums GitHub Releases asset download counts
-        // per platform across every tag. Only counts the primary user-facing
-        // asset for each platform (zip / tar.gz / dmg / setup exe), not the
-        // .sig / .pem signature siblings, so the count matches "actual humans
-        // who downloaded the binary".
+        // per platform across every tag, for EVERY installer format
+        // (tar.gz / deb / rpm / AppImage / dmg / exe / msi / zip), excluding only
+        // the .sig / .pem / SHA256SUMS siblings. NOTE: GitHub's download_count is
+        // raw asset fetches — it includes bots, crawlers, mirrors, CI, and every
+        // run of the install scripts, sums multiple formats per release, and
+        // can't dedup people, so this is a downloads figure, NOT unique installs.
         (function loadDownloadCounter() {
             const elLinux   = document.getElementById('dl-linux');
             const elMac     = document.getElementById('dl-mac');
@@ -2276,13 +2278,14 @@
             const isPrimaryAsset = (name) => {
                 if (name.endsWith('.sig') || name.endsWith('.pem')) return false;
                 if (name === 'SHA256SUMS') return false;
-                return /\.tar\.gz$|\.dmg$|\.zip$|\.exe$/.test(name);
+                return /\.tar\.gz$|\.dmg$|\.zip$|\.exe$|\.msi$|\.deb$|\.rpm$|\.appimage$/i.test(name);
             };
 
             const platformOf = (name) => {
-                if (/linux/i.test(name)) return 'linux';
-                if (/macos|mac-|darwin|\.dmg$/i.test(name)) return 'mac';
-                if (/windows|win-|\.exe$/i.test(name) || name.endsWith('.zip')) return 'windows';
+                const n = name.toLowerCase();
+                if (/\.dmg$|macos|darwin|mac-/.test(n)) return 'mac';
+                if (/\.msi$|\.exe$|\.zip$|windows|win-/.test(n)) return 'windows';
+                if (/\.tar\.gz$|\.deb$|\.rpm$|\.appimage$|linux/.test(n)) return 'linux';
                 return null;
             };
 
@@ -2307,7 +2310,7 @@
                 elMac.textContent     = fmt(counts.mac);
                 elWindows.textContent = fmt(counts.windows);
                 const total = counts.linux + counts.mac + counts.windows;
-                elTotal.textContent = `${fmt(total)} total · live from GitHub Releases API · last refreshed ${new Date().toLocaleTimeString()}`;
+                elTotal.textContent = `${fmt(total)} GitHub asset downloads · all installer formats, every fetch (incl. bots / CI / mirrors) — not unique installs · live from the GitHub Releases API · refreshed ${new Date().toLocaleTimeString()}`;
             })
             .catch(err => {
                 elTotal.textContent = 'GitHub API rate-limited — try refreshing in a minute';

--- a/test_ai_write_gate.cpp
+++ b/test_ai_write_gate.cpp
@@ -58,7 +58,9 @@
 
 #include <cstdio>
 #include <cstdlib>
+#ifndef _WIN32
 #include <unistd.h>   // geteuid — skip the read-only-dir case when running as root
+#endif
 
 static int g_pass = 0, g_fail = 0, g_skip = 0;
 
@@ -453,8 +455,16 @@ static void testAtomicWrite() {
     //     the filesystem does not actually enforce the read-only dir (probed
     //     below) — either way the perms wouldn't bite and asserting would be a
     //     false failure rather than a real signal.
-    if (geteuid() == 0) {
-        skip("blocked-write-preserves-original", "running as root; dir perms don't bite");
+#ifdef _WIN32
+    // Windows has no POSIX euid, and NTFS does not honor POSIX-style read-only
+    // dir permissions via QFile::setPermissions — the enforcement probe below
+    // would report "not enforced" anyway, so skip this sub-case outright.
+    const bool rootBypassesDirPerms = true;
+#else
+    const bool rootBypassesDirPerms = (geteuid() == 0);
+#endif
+    if (rootBypassesDirPerms) {
+        skip("blocked-write-preserves-original", "root or non-POSIX FS; dir perms don't bite");
     } else {
         const QString roDir = tmp.path() + "/ro";
         QDir().mkpath(roDir);


### PR DESCRIPTION
## Why
The `v0.1.115` tag build **failed on `build-windows`** — `test_ai_write_gate.cpp` included `<unistd.h>` (POSIX-only) for `geteuid()`, which MSVC doesn't have → `C1083`, failing the regression-suite step. The `release` job was correctly **skipped, so v0.1.115 never published.** Linux x64/ARM and macOS all built + tested green.

## Fix (2 commits)
1. **`fix(test)`** — guard `<unistd.h>` with `#ifndef _WIN32` and make the root-check cross-platform. On Windows there's no POSIX euid and NTFS doesn't honor `QFile` read-only dir perms, so the read-only-dir atomic-write sub-case skips (the enforcement probe would report the same). **No behavior change on Linux/macOS**: `test_ai_write_gate` 61/61, full offscreen ctest **70/70**.
2. **`docs`** — honest download counter: now sums **all** installer formats (`.msi`/`.deb`/`.rpm`/`.AppImage` were silently dropped) and is relabeled **"GitHub asset downloads"** with an explicit note that `download_count` is raw fetches (bots/CI/mirrors/repeat), **not** unique installs.

## After merge
Re-tag `v0.1.115` on the new `main` HEAD → CI re-runs → this time the Windows build passes and the release publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)