### PR TITLE
ci: harden NSIS install fallback — retry choco + fail fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1688,7 +1688,9 @@ jobs:
       # Produces notepatra-setup-<VERSION>.exe which registers in "Installed
       # apps" via HKCU Uninstall key, generates uninstall.exe, creates Start
       # Menu + Desktop shortcuts, and optionally adds notepatra to the user
-      # PATH. NSIS ships pre-installed on windows-latest runners.
+      # PATH. The runner image no longer ships NSIS pre-installed, so the
+      # chocolatey fallback is the normal path; community.chocolatey.org
+      # throws transient 504s, hence the retry + hard verify below.
       - name: Build Windows installer (NSIS)
         shell: pwsh
         run: |
@@ -1709,8 +1711,17 @@ jobs:
           }
           if (-not $makensis) {
               Write-Host "::warning::NSIS not found on runner — installing via chocolatey"
-              choco install nsis -y --no-progress
               $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
+              foreach ($attempt in 1..3) {
+                  choco install nsis -y --no-progress
+                  if (Test-Path $makensis) { break }
+                  Write-Host "::warning::choco install nsis did not produce makensis.exe (attempt $attempt/3)"
+                  if ($attempt -lt 3) { Start-Sleep -Seconds (30 * $attempt) }
+              }
+          }
+          if (-not (Test-Path $makensis)) {
+              Write-Host "::error::makensis.exe not found at $makensis — NSIS install failed after retries"
+              exit 1
           }
           Write-Host "Using makensis: $makensis"
 
@@ -1750,8 +1761,17 @@ jobs:
               }
           }
           if (-not $makensis) {
-              choco install nsis -y --no-progress
               $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
+              foreach ($attempt in 1..3) {
+                  choco install nsis -y --no-progress
+                  if (Test-Path $makensis) { break }
+                  Write-Host "::warning::choco install nsis did not produce makensis.exe (attempt $attempt/3)"
+                  if ($attempt -lt 3) { Start-Sleep -Seconds (30 * $attempt) }
+              }
+          }
+          if (-not (Test-Path $makensis)) {
+              Write-Host "::error::makensis.exe not found at $makensis — NSIS install failed after retries"
+              exit 1
           }
           Write-Host "Using makensis: $makensis"
 


### PR DESCRIPTION
## What broke

Run 29056502306 (main push, PR #24 merge) failed in **Build Windows installer (NSIS)**:

1. The Windows runner image no longer ships NSIS pre-installed — the chocolatey fallback now fires on **every** run.
2. `choco install nsis` hit a transient **504 Gateway Timeout** from community.chocolatey.org (`Chocolatey installed 0/0 packages`).
3. The step blindly proceeded with the hardcoded `C:\Program Files (x86)\NSIS\makensis.exe` path → confusing 'term not recognized' failure 80 minutes into the job.

No release impact: non-tag push, `release` job skipped; the identical commit's PR run and the v0.1.116 tag run both passed.

## Fix (both NSIS steps, Lite + Full)

- Retry `choco install nsis` up to 3 attempts with 30s/60s backoff, using **the actual presence of makensis.exe** as the success test (not choco's exit code)
- Hard-fail immediately with a clear `::error` if makensis.exe is still missing after retries
- Correct the stale "NSIS ships pre-installed on windows-latest runners" comment

CI-only change — no source, docs, or installer-script changes. YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)